### PR TITLE
Fixed linting warnings

### DIFF
--- a/lib/diskutil.js
+++ b/lib/diskutil.js
@@ -121,7 +121,7 @@ const listAll = (callback) => {
 
     // NOTE: `diskutil list -plist` can give back 'null' data when recovering
     // from a system sleep / stand-by
-    if (data == null) {
+    if (data === null) {
       error = error || new Error(`Command "${cmd} ${argv.join(' ')}" returned without data`);
     }
 
@@ -151,7 +151,7 @@ const list = (callback) => {
 
         // NOTE: `diskutil` can return 'null' when recovering
         // from a system sleep / stand-by
-        if (data == null) {
+        if (data === null) {
           error = error || new Error(`Command "diskutil info -plist ${devicePath}}" returned without data`);
         }
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -27,7 +27,7 @@ const exec = (cmd, argv, callback) => {
     .on('exit', (code, signal) => {
       let error = null;
 
-      if (code == null || code !== 0) {
+      if (code === null || code !== 0) {
         error = error || new Error(`Command "${cmd} ${argv.join(' ')}" exited unexpectedly with "${code || signal}"`);
         error.code = code;
         error.signal = signal;

--- a/tests/diskutil.spec.js
+++ b/tests/diskutil.spec.js
@@ -87,6 +87,16 @@ describe('Drivelist', function() {
       });
     });
 
+    it('plist undefined and null value assertions', function() {
+      const listData = fs.readFileSync(path.join(__dirname, 'data', 'diskutil', 'no-partition-list.plist'), 'utf8');
+      const globalList = plist.parse(listData);
+
+      m.chai.expect(globalList.nonExistingProperty === null).to.equal(false);
+      m.chai.expect(typeof globalList.nonExistingProperty === 'undefined').to.equal(true);
+
+      const noData = plist.parse('');
+      m.chai.expect(noData === null).to.equal(true);
+    });
   });
 
 });

--- a/tests/drivelist.spec.js
+++ b/tests/drivelist.spec.js
@@ -74,31 +74,31 @@ describe('Drivelist', function() {
             `Invalid mountpoints: ${device.mountpoints}`
           );
           assert.ok(
-            device.isReadOnly == null || typeof device.isReadOnly === 'boolean',
+            device.isReadOnly === null || typeof device.isReadOnly === 'boolean',
             `Invalid isReadOnly flag: ${device.isReadOnly}`
           );
           assert.ok(
-            device.isSystem == null || typeof device.isSystem === 'boolean',
+            device.isSystem === null || typeof device.isSystem === 'boolean',
             `Invalid isSystem flag: ${device.isSystem}`
           );
           assert.ok(
-            device.isVirtual == null || typeof device.isVirtual === 'boolean',
+            device.isVirtual === null || typeof device.isVirtual === 'boolean',
             `Invalid isVirtual flag: ${device.isVirtual}`
           );
           assert.ok(
-            device.isRemovable == null || typeof device.isRemovable === 'boolean',
+            device.isRemovable === null || typeof device.isRemovable === 'boolean',
             `Invalid isRemovable flag: ${device.isRemovable}`
           );
           assert.ok(
-            device.isCard == null || typeof device.isCard === 'boolean',
+            device.isCard === null || typeof device.isCard === 'boolean',
             `Invalid isCard flag: ${device.isCard}`
           );
           assert.ok(
-            device.isSCSI == null || typeof device.isSCSI === 'boolean',
+            device.isSCSI === null || typeof device.isSCSI === 'boolean',
             `Invalid isSCSI flag: ${device.isSCSI}`
           );
           assert.ok(
-            device.isUSB == null || typeof device.isUSB === 'boolean',
+            device.isUSB === null || typeof device.isUSB === 'boolean',
             `Invalid isUSB flag: ${device.isUSB}`
           );
           assert.ok(


### PR DESCRIPTION
This PR fixes the eqeqeq linting warnings, also added an spec with assertions of the return value for the `require('fast-plist').parse` function since return values on zero length strings is undocumented.

`childProcess.spawn(...).on('exit')` is [documented](https://nodejs.org/api/child_process.html#child_process_event_exit) to return null or number, so the eqeqeq change is safe.