### PR TITLE
Fix macos crash

### DIFF
--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -130,6 +130,7 @@ namespace Drivelist {
       deviceList.push_back(device);
 
       CFRelease(diskDescription);
+      CFRelease(disk);
     }
 
     // Add mount points
@@ -148,6 +149,7 @@ namespace Drivelist {
 
       const char *bsdnameChar = DADiskGetBSDName(disk);
       if (bsdnameChar == nil) {
+        CFRelease(disk);
         continue;
       }
 
@@ -166,6 +168,8 @@ namespace Drivelist {
           break;
         }
       }
+
+      CFRelease(disk);
     }
 
     return deviceList;

--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -33,12 +33,21 @@ namespace Drivelist {
       diskDescription,
       kDADiskDescriptionMediaIconKey
     );
-    NSString *iconFileName = (NSString*)CFDictionaryGetValue(
-      mediaIconDict,
-      CFStringCreateWithCString(NULL, "IOBundleResourceFile", kCFStringEncodingUTF8)
-    );
+    if (mediaIconDict == nil) {
+      return false;
+    }
 
-    return [iconFileName isEqualToString:@"SD.icns"];
+    CFStringRef iconFileNameKeyRef = CFStringCreateWithCString(NULL, "IOBundleResourceFile", kCFStringEncodingUTF8);
+    CFStringRef iconFileNameRef = (CFStringRef)CFDictionaryGetValue(mediaIconDict, iconFileNameKeyRef);
+    CFRelease(iconFileNameKeyRef);
+
+    if (iconFileNameRef == nil) {
+      return false;
+    }
+
+    // macOS 10.14.3 - External SD card reader provides `Removable.icns`, not `SD.icns`.
+    // But we can't use it to detect SD card, because external drive has `Removable.icns` as well.
+    return [(NSString *)iconFileNameRef isEqualToString:@"SD.icns"];
   }
 
   NSNumber *DictNum(CFDictionaryRef dict, const void *key) {

--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -50,16 +50,16 @@ namespace Drivelist {
     return [(NSString *)iconFileNameRef isEqualToString:@"SD.icns"];
   }
 
-  NSNumber *DictNum(CFDictionaryRef dict, const void *key) {
+  NSNumber *DictionaryGetNumber(CFDictionaryRef dict, const void *key) {
     return (NSNumber*)CFDictionaryGetValue(dict, key);
   }
 
   DeviceDescriptor CreateDeviceDescriptorFromDiskDescription(std::string diskBsdName, CFDictionaryRef diskDescription) {
     NSString *busType = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceProtocolKey);
-    NSNumber *blockSize = DictNum(diskDescription, kDADiskDescriptionMediaBlockSizeKey);
-    bool isInternal = [DictNum(diskDescription, kDADiskDescriptionDeviceInternalKey) boolValue];
-    bool isRemovable = [DictNum(diskDescription, kDADiskDescriptionMediaRemovableKey) boolValue];
-    bool isEjectable = [DictNum(diskDescription, kDADiskDescriptionMediaEjectableKey) boolValue];
+    NSNumber *blockSize = DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaBlockSizeKey);
+    bool isInternal = [DictionaryGetNumber(diskDescription, kDADiskDescriptionDeviceInternalKey) boolValue];
+    bool isRemovable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaRemovableKey) boolValue];
+    bool isEjectable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaEjectableKey) boolValue];
     NSString *mediaType = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionMediaTypeKey);
 
     DeviceDescriptor device = DeviceDescriptor();
@@ -82,8 +82,8 @@ namespace Drivelist {
     //      diskutil info / | grep "Block Size"
     device.blockSize = [blockSize unsignedIntValue];
     device.logicalBlockSize = [blockSize unsignedIntValue];
-    device.size = [DictNum(diskDescription, kDADiskDescriptionMediaSizeKey) unsignedLongValue];
-    device.isReadOnly = ![DictNum(diskDescription, kDADiskDescriptionMediaWritableKey) boolValue];
+    device.size = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaSizeKey) unsignedLongValue];
+    device.isReadOnly = ![DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaWritableKey) boolValue];
     device.isSystem = isInternal && !isRemovable;
     device.isVirtual = ![mediaType isEqualToString:@"physical"];
     device.isRemovable = isRemovable || isEjectable;

--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -66,6 +66,10 @@ namespace Drivelist {
       }
 
       CFDictionaryRef diskDescription = DADiskCopyDescription(disk);
+      if (diskDescription == nil) {
+        CFRelease(disk);
+        continue;
+      }
 
       NSString *busType = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceProtocolKey);
       NSNumber *blockSize = DictNum(diskDescription, kDADiskDescriptionMediaBlockSizeKey);


### PR DESCRIPTION
It fixes #329. I modified the test file a bit (attached at the end of this message). This PR:

* Fixes macOS crash when SD card is ejected
* Moves `DeviceDescription` creation to a separate function
* Adds couple of missing `CFRelease` calls (memory leaks)
* Makes `Drivelist::IsCard` more robust

`index.ts` I was using for tests:

```typescript
import { inspect } from 'util';
import { list } from '..';

async function main() {
  var last_count = -1;
  while (true) {
    let drives;
    try {
      drives = await list();
    } catch (error) {
      console.error(error);
      process.exitCode = 1;
      return;
    }

    if (last_count != drives.length) {
      last_count = drives.length;
      console.log(last_count);
    }
  }
}

main();
```