### PR TITLE
Fix isVirtual value for DMG & TimeMachine on macOS

### DIFF
--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -56,7 +56,6 @@ namespace Drivelist {
 
   DeviceDescriptor CreateDeviceDescriptorFromDiskDescription(std::string diskBsdName, CFDictionaryRef diskDescription) {
     NSString *deviceProtocol = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceProtocolKey);
-    NSString *deviceModel = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceModelKey);
     NSNumber *blockSize = DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaBlockSizeKey);
     bool isInternal = [DictionaryGetNumber(diskDescription, kDADiskDescriptionDeviceInternalKey) boolValue];
     bool isRemovable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaRemovableKey) boolValue];
@@ -85,7 +84,7 @@ namespace Drivelist {
     device.size = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaSizeKey) unsignedLongValue];
     device.isReadOnly = ![DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaWritableKey) boolValue];
     device.isSystem = isInternal && !isRemovable;
-    device.isVirtual = [deviceProtocol isEqualToString:@"Virtual Interface"] || [deviceModel isEqualToString:@"Disk Image"];
+    device.isVirtual = [deviceProtocol isEqualToString:@"Virtual Interface"];
     device.isRemovable = isRemovable || isEjectable;
     device.isCard = IsCard(diskDescription);
     // NOTE(robin): Not convinced that these bus types should result

--- a/src/darwin/list.mm
+++ b/src/darwin/list.mm
@@ -55,16 +55,16 @@ namespace Drivelist {
   }
 
   DeviceDescriptor CreateDeviceDescriptorFromDiskDescription(std::string diskBsdName, CFDictionaryRef diskDescription) {
-    NSString *busType = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceProtocolKey);
+    NSString *deviceProtocol = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceProtocolKey);
+    NSString *deviceModel = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionDeviceModelKey);
     NSNumber *blockSize = DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaBlockSizeKey);
     bool isInternal = [DictionaryGetNumber(diskDescription, kDADiskDescriptionDeviceInternalKey) boolValue];
     bool isRemovable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaRemovableKey) boolValue];
     bool isEjectable = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaEjectableKey) boolValue];
-    NSString *mediaType = (NSString*)CFDictionaryGetValue(diskDescription, kDADiskDescriptionMediaTypeKey);
 
     DeviceDescriptor device = DeviceDescriptor();
     device.enumerator = "DiskArbitration";
-    device.busType = [busType UTF8String];
+    device.busType = [deviceProtocol UTF8String];
     device.busVersion = "";
     device.busVersionNull = true;
     device.device = "/dev/" + diskBsdName;
@@ -85,15 +85,15 @@ namespace Drivelist {
     device.size = [DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaSizeKey) unsignedLongValue];
     device.isReadOnly = ![DictionaryGetNumber(diskDescription, kDADiskDescriptionMediaWritableKey) boolValue];
     device.isSystem = isInternal && !isRemovable;
-    device.isVirtual = ![mediaType isEqualToString:@"physical"];
+    device.isVirtual = [deviceProtocol isEqualToString:@"Virtual Interface"] || [deviceModel isEqualToString:@"Disk Image"];
     device.isRemovable = isRemovable || isEjectable;
     device.isCard = IsCard(diskDescription);
     // NOTE(robin): Not convinced that these bus types should result
     // in device.isSCSI = true, it is rather "not usb or sd drive" bool
     // But the old implementation was like this so kept it this way
     NSArray *scsiTypes = [NSArray arrayWithObjects:@"SATA", @"SCSI", @"ATA", @"IDE", @"PCI", nil];
-    device.isSCSI = [scsiTypes containsObject:busType];
-    device.isUSB = [busType isEqualToString:@"USB"];
+    device.isSCSI = [scsiTypes containsObject:deviceProtocol];
+    device.isUSB = [deviceProtocol isEqualToString:@"USB"];
     device.isUAS = false;
     device.isUASNull = true;
 


### PR DESCRIPTION
`drivelist` on macOS sets `isVirtual` flag to `true` if:

* `kDADiskDescriptionDeviceProtocolKey` equals to `Virtual Interface` ~~**OR**~~
* ~~`kDADiskDescriptionDeviceModelKey` equals to `Disk Image`.~~

~~It's probably enough to use just one of these, but I've decided to use both of them. It seems that this is constantly changing between macOS releases. It should still work if Apple decides to change value of one of those keys. If you'd like to use just one, let me know and I'll remove the other.~~

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>