### PR TITLE
Fix mac os crash

### DIFF
--- a/src/darwin/REDiskList.m
+++ b/src/darwin/REDiskList.m
@@ -21,6 +21,8 @@
 @implementation REDiskList
 
 - (id)init {
+  self = [super init];
+
   if (self) {
     _disks = [[NSMutableArray alloc] init];
     [self populateDisksBlocking];

--- a/src/darwin/REDiskList.m
+++ b/src/darwin/REDiskList.m
@@ -18,11 +18,7 @@
 #import "REDiskList.h"
 #import <DiskArbitration/DiskArbitration.h>
 
-@implementation REDiskList {
-  NSMutableArray *_disks;
-}
-
-@synthesize disks = _disks;
+@implementation REDiskList
 
 - (id)init {
   if (self) {

--- a/src/darwin/REDiskList.m
+++ b/src/darwin/REDiskList.m
@@ -53,6 +53,7 @@ void appendDisk(DADiskRef disk, void *context) {
     DASessionScheduleWithRunLoop(session, runLoop, kCFRunLoopDefaultMode);
     CFRunLoopStop(runLoop);
     CFRunLoopRunInMode((CFStringRef)NSDefaultRunLoopMode, 0.05, NO);
+    DAUnregisterCallback(session, appendDisk, (void*)_disks);
     CFRelease(session);
   }
 }


### PR DESCRIPTION
This PR:

* removes unnecessary boilerplate
* adds missing `[super init]` call
* adds callback unregistration

Why this worked before? Because of memory leak, `_disk` was alive and then `context` pointer in the `appendDisk` callback was still valid. But now, since we're properly releasing the `_disk`, it can be invalid if we keep `appendDisk` callback around, because `context` can point to a garbage.