### PR TITLE
Modify example code to work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Examples (the output will vary depending on your machine):
 ```js
 const drivelist = require('drivelist');
 
-const drives = await drivelist.list();
-console.log(drives);
+getDrives();
+
+async function getDrives () {
+    const drives = await drivelist.list();
+    console.log(drives);
+}
 ```
 
 ***
@@ -173,10 +177,14 @@ Documentation
 ```js
 const drivelist = require('drivelist');
 
-const drives = await drivelist.list();
-drives.forEach((drive) => {
-  console.log(drive);
-});
+getDrives();
+
+async function getDrives () {
+    const drives = await drivelist.list();
+    drives.forEach((drive) => {
+        console.log(drive);
+      });
+}
 ```
 
 Tests


### PR DESCRIPTION
When testing the old example code I would get the following error:

const drives = await drivelist.list();
               ^^^^^
SyntaxError: await is only valid in async function

I have modified the example code so you can cut, paste and run without error.