### PR TITLE
Make drivelist content aware

### DIFF
--- a/src/drivelist.cpp
+++ b/src/drivelist.cpp
@@ -63,4 +63,8 @@ NAN_MODULE_INIT(InitAll) {
   NAN_EXPORT(target, list);
 }
 
-NODE_MODULE(DriveList, InitAll);
+#if NODE_MAJOR_VERSION >= 10
+NAN_MODULE_WORKER_ENABLED(DriveList, InitAll)
+#else
+NODE_MODULE(DriveList, InitAll)
+#endif


### PR DESCRIPTION
Make drivelist content aware, see: https://github.com/electron/electron/issues/18397

Without this, the following warning is displayed when using Electron 8+:

> (node:82420) Electron: Loading non-context-aware native module in renderer: '/Users/foo/repos/app/node_modules/drivelist/build/Release/drivelist.node'.

fixes #373