### PR TITLE
Remove repo config from flowzone.yml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,5 +1,4 @@
 name: Flowzone
-
 on:
   pull_request:
     types: [opened, synchronize, closed]
@@ -8,7 +7,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, closed]
     branches: [main, master]
-
 jobs:
   flowzone:
     name: Flowzone
@@ -22,5 +20,3 @@ jobs:
     with:
       tests_run_on: '["ubuntu-latest","macos-latest","windows-2019"]'
       restrict_custom_actions: false
-      repo_config: true
-      repo_description: "List all connected drives in your computer, in all major operating systems"


### PR DESCRIPTION
This functionality is being deprecated in Flowzone.

See: https://github.com/product-os/flowzone/pull/833

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
