### PR TITLE
bump node-gyp version to 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "^8.31.0",
     "jsdoc-to-markdown": "^8.0.0",
     "mocha": "^10.2.0",
-    "node-gyp": "^9.3.1",
+    "node-gyp": "^10.0.1",
     "prebuild": "^11.0.4",
     "sinon": "^15.0.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
For compatibility with Python v3.12 and beyond since distutils has been "removed from the standard library". [Python 3.12 Changelog](https://docs.python.org/3/whatsnew/3.12.html#summary-release-highlights)