### PR TITLE
Replace deprecated flowzone input tests_run_on

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -18,5 +18,5 @@ jobs:
       (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
     with:
-      tests_run_on: '["ubuntu-latest","macos-latest","windows-2019"]'
+      tests_run_on: '[["ubuntu-latest"],["macos-latest"],["windows-2019"]]'
       restrict_custom_actions: false


### PR DESCRIPTION
The `custom_runs_on` array supports multiple runner labels in nested arrays.

The new input also allows the use of self-hosted runners as they require multiple labels to identify.

Change-type: patch